### PR TITLE
For discussion 

### DIFF
--- a/src/tr1d1um/stat/transport.go
+++ b/src/tr1d1um/stat/transport.go
@@ -81,6 +81,9 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 //do we care to make that distinction?
 func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) (err error) {
 	resp := response.(*common.XmidtResponse)
+	if resp.Code == 500 {
+		w.Header().Set("xMiDT_statusCode": "500")
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set(common.HeaderWPATID, ctx.Value(common.ContextKeyRequestTID).(string))


### PR DESCRIPTION
per se  

Unsure what would be a suitable header to store a statusCode reported from a different machine. 

//TODO: What about if XMiDT cluster reports 500. There would be ambiguity
//about which machine is actually having the error (Tr1d1um or the Xmidt API)
//do we care to make that distinction?
