### PR TITLE
Feature/ci/rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ rpm:
 	mkdir -p ./.ignore/SOURCES
 	tar -czf ./.ignore/SOURCES/$(APP)-$(PROGVER).tar.gz --transform 's/^\./$(APP)-$(PROGVER)/' --exclude ./keys --exclude ./.git --exclude ./.ignore --exclude ./conf --exclude ./deploy --exclude ./vendor --exclude ./src/vendor .
 	cp etc/systemd/$(APP).service ./.ignore/SOURCES/
-	cp etc/$(APP)/$(APP).yaml  ./.ignore/SOURCES/
+	cp -L etc/$(APP)/$(APP).yaml  ./.ignore/SOURCES/
+	cp LICENSE ./.ignore/SOURCES
+	cp CHANGELOG.md ./.ignore/SOURCES
 	rpmbuild --define "_topdir $(CURDIR)/.ignore" \
 		--define "_ver $(PROGVER)" \
 		--define "_releaseno $(RELEASE)" \

--- a/etc/systemd/tr1d1um.spec
+++ b/etc/systemd/tr1d1um.spec
@@ -34,10 +34,10 @@ popd
 %{__install} -D -p -m 755 src/%{name}/%{name} %{buildroot}%{_bindir}/%{name}
 
 # Install Service
-%{__install} -D -p -m 644 etc/systemd/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
+%{__install} -D -p -m 644 %{_builddir}/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
 
 # Install Configuration
-%{__install} -D -p -m 644 etc/%{name}/%{name}.yaml %{buildroot}%{_sysconfdir}/%{name}/%{name}.yaml
+%{__install} -D -p -m 644 %{_builddir}/%{name}.yaml %{buildroot}%{_sysconfdir}/%{name}/%{name}.yaml
 
 
 # Create Logging Location

--- a/etc/systemd/tr1d1um.spec
+++ b/etc/systemd/tr1d1um.spec
@@ -34,10 +34,10 @@ popd
 %{__install} -D -p -m 755 src/%{name}/%{name} %{buildroot}%{_bindir}/%{name}
 
 # Install Service
-%{__install} -D -p -m 644 %{_builddir}/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
+%{__install} -D -p -m 644 %{_sourcedir}/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
 
 # Install Configuration
-%{__install} -D -p -m 644 %{_builddir}/%{name}.yaml %{buildroot}%{_sysconfdir}/%{name}/%{name}.yaml
+%{__install} -D -p -m 644 %{_sourcedir}/%{name}.yaml %{buildroot}%{_sysconfdir}/%{name}/%{name}.yaml
 
 
 # Create Logging Location


### PR DESCRIPTION
Changes introduced:

- Since config.yaml is a symbolic link, let's use the -L flag to ensure the source file is copied and not just the link.
- Copy LICENSE and CHANGELOG.md files into RPM
- Use the RPM defined macros for installations in the tr1d1um.spec file