### PR TITLE
Improve user error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- fix a bug in which tr1d1um was returning 500 for user error requests [#146](https://github.com/xmidt-org/tr1d1um/pull/146)
 
 ## [v0.3.0]
  - add feature to disable verbose transaction logger [#145](https://github.com/xmidt-org/tr1d1um/pull/145)

--- a/translation/errors.go
+++ b/translation/errors.go
@@ -19,7 +19,9 @@ var (
 	//Add/Delete command  errors
 	ErrMissingTable = common.NewBadRequestError(errors.New("table property is required"))
 	ErrMissingRow   = common.NewBadRequestError(errors.New("row property is required"))
+	ErrInvalidRow   = common.NewBadRequestError(errors.New("row property is invalid"))
 
 	//Replace command error
 	ErrMissingRows = common.NewBadRequestError(errors.New("rows property is required"))
+	ErrInvalidRows = common.NewBadRequestError(errors.New("rows property is invalid"))
 )

--- a/translation/transport_test.go
+++ b/translation/transport_test.go
@@ -275,6 +275,15 @@ func TestRequestAddPayload(t *testing.T) {
 		assert.EqualValues(ErrMissingRow, e)
 	})
 
+	t.Run("RowInvalidProvided", func(t *testing.T) {
+		assert := assert.New(t)
+
+		p, e := requestAddPayload(map[string]string{"parameter": "t0"}, bytes.NewBufferString("invalid row"))
+
+		assert.Nil(p)
+		assert.EqualValues(ErrInvalidRow, e)
+	})
+
 	t.Run("IdealPath", func(t *testing.T) {
 		assert := assert.New(t)
 		p, e := requestAddPayload(map[string]string{"parameter": "t0"}, bytes.NewBufferString(`{"row": "r0"}`))
@@ -311,6 +320,15 @@ func TestRequestReplacePayload(t *testing.T) {
 
 		assert.Nil(p)
 		assert.EqualValues(ErrMissingRows, e)
+	})
+
+	t.Run("RowsInvalidProvided", func(t *testing.T) {
+		assert := assert.New(t)
+
+		p, e := requestReplacePayload(map[string]string{"parameter": "t0"}, bytes.NewBufferString("invalid rows"))
+
+		assert.Nil(p)
+		assert.EqualValues(ErrInvalidRows, e)
 	})
 
 	t.Run("IdealPath", func(t *testing.T) {

--- a/translation/transport_test.go
+++ b/translation/transport_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xmidt-org/wrp-go/wrp"
 	"github.com/xmidt-org/wrp-go/wrp/wrphttp"
 
@@ -138,6 +139,17 @@ func TestRequestPayload(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPatch, "http://localhost", nil)
 		_, e := requestPayload(r)
 		assert.EqualValues(ErrInvalidSetWDMP, e)
+	})
+
+	t.Run("SetWithBody", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		r := httptest.NewRequest(http.MethodPatch, "http://localhost", bytes.NewBufferString("invalidWDMP"))
+		_, e := requestPayload(r)
+		err, ok := e.(common.CodedError)
+		require.True(ok)
+		assert.Contains(e.Error(), "Invalid WDMP structure")
+		assert.EqualValues(http.StatusBadRequest, err.StatusCode())
 	})
 
 	t.Run("Del", func(t *testing.T) {

--- a/translation/transport_utils.go
+++ b/translation/transport_utils.go
@@ -172,11 +172,9 @@ func getParamNames(params []setParam) (paramNames []string) {
 }
 
 func contains(i string, elements []string) bool {
-	if elements != nil {
-		for _, e := range elements {
-			if e == i {
-				return true
-			}
+	for _, e := range elements {
+		if e == i {
+			return true
 		}
 	}
 	return false

--- a/translation/transport_utils_test.go
+++ b/translation/transport_utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xmidt-org/tr1d1um/common"
 	"github.com/xmidt-org/webpa-common/device"
 	"github.com/xmidt-org/wrp-go/wrp"
 )
@@ -159,7 +160,7 @@ func TestWrapInWRP(t *testing.T) {
 		w, e := wrap([]byte(""), "", nil, nil)
 
 		assert.Nil(w)
-		assert.EqualValues(device.ErrorInvalidDeviceName, e)
+		assert.EqualValues(common.NewBadRequestError(device.ErrorInvalidDeviceName), e)
 	})
 
 	t.Run("GivenParameters", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes the bug in which tr1d1um responded with a 500 Internal Server error for cases that are clearly user errors:
- Invalid MAC Addresses for device ID
- Invalid Table Row structures for Add and Replace WDMP requests
