### PR TITLE
Copr spec file parser does not like '%S' 

### DIFF
--- a/deploy/packaging/tr1d1um.spec
+++ b/deploy/packaging/tr1d1um.spec
@@ -26,7 +26,7 @@ The Webpa object translator.
 %setup -q
 
 %build
-GO111MODULE=on GOPROXY=https://proxy.golang.org go build -ldflags "-linkmode=external -X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit={{{ git_short_hash }}} -X main.Version=%{version}" -o %{name} .
+GO111MODULE=on GOPROXY=https://proxy.golang.org go build -ldflags "-linkmode=external -X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M'`' -X main.GitCommit={{{ git_short_hash }}} -X main.Version=%{version}" -o %{name} .
 
 %install
 echo rm -rf %{buildroot}

--- a/deploy/packaging/tr1d1um.spec
+++ b/deploy/packaging/tr1d1um.spec
@@ -26,7 +26,7 @@ The Webpa object translator.
 %setup -q
 
 %build
-GO111MODULE=on GOPROXY=https://proxy.golang.org go build -ldflags "-linkmode=external -X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M'`' -X main.GitCommit={{{ git_short_hash }}} -X main.Version=%{version}" -o %{name} .
+date --version
 
 %install
 echo rm -rf %{buildroot}

--- a/deploy/packaging/tr1d1um.spec
+++ b/deploy/packaging/tr1d1um.spec
@@ -26,7 +26,7 @@ The Webpa object translator.
 %setup -q
 
 %build
-date --version
+GOPROXY=https://proxy.golang.org go build -ldflags "-linkmode=external -X 'main.BuildTime=`date -u '+%c'`' -X main.GitCommit={{{ git_short_hash }}} -X main.Version=%{version}" -o %{name} .
 
 %install
 echo rm -rf %{buildroot}


### PR DESCRIPTION
Debugging why copr builds are failing:
```
Writing config into /tmp/copr-rpmbuild-algqo_4b/obtain-sources/.config/rpkg.conf
Running: rpkg srpm --outdir /tmp/copr-rpmbuild-algqo_4b --spec /tmp/copr-rpmbuild-algqo_4b/obtain-sources/tr1d1um/deploy/packaging/tr1d1um.spec

cmd: ['rpkg', 'srpm', '--outdir', '/tmp/copr-rpmbuild-algqo_4b', '--spec', '/tmp/copr-rpmbuild-algqo_4b/obtain-sources/tr1d1um/deploy/packaging/tr1d1um.spec']
cwd: /tmp/copr-rpmbuild-algqo_4b/obtain-sources/tr1d1um
rc: 0
stdout: Wrote: /tmp/copr-rpmbuild-algqo_4b/tr1d1um.spec
stderr: error: /tmp/copr-rpmbuild-algqo_4b/tr1d1um.spec: line 29: %S: argument expected
can't parse specfile

Output: ['tr1d1um.spec']
```