### PR TITLE
fix casting bug for fetching partnerIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bug in which Tr1d1um was not capturing partnerIDs correctly due to casting error. [#182](https://github.com/xmidt-org/tr1d1um/pull/182)
 
 ## [v0.5.3]
-### Fixed 
+### Fixed
 - Bug in which only mTLS was allowed as valid config for a webpa server. [#181](https://github.com/xmidt-org/tr1d1um/pull/181)
 
 ## [v0.5.2]

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/goph/emperror v0.17.3-0.20190703203600-60a8d9faa17b
 	github.com/gorilla/mux v1.7.4
 	github.com/justinas/alice v1.2.0
+	github.com/spf13/cast v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.5.1

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -12,6 +12,7 @@ import (
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
+	"github.com/spf13/cast"
 
 	"github.com/xmidt-org/bascule"
 	"github.com/xmidt-org/tr1d1um/common"
@@ -104,8 +105,9 @@ func getPartnerIDsDecodeRequest(ctx context.Context, r *http.Request) []string {
 	if !ok {
 		return getPartnerIDs(r.Header)
 	}
-	partnerIDs, ok := partnerVal.([]string)
-	if !ok {
+	partnerIDs, err := cast.ToStringSliceE(partnerVal)
+
+	if err != nil {
 		return getPartnerIDs(r.Header)
 	}
 	return partnerIDs


### PR DESCRIPTION
The direct casting to `[]string` was failing because the partnerIDs list is of type `[]interface{}` internally. This is an issue @kristinaspring already found and fixed in another service recently.