### PR TITLE
Release: Metric Server Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.7.11]
 - [No Prom Metrics Being Produced #329](https://github.com/xmidt-org/tr1d1um/issues/329)
 
 ## [v0.7.10]
@@ -184,7 +186,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial creation.
 
-[Unreleased]: https://github.com/xmidt-org/tr1d1um/compare/v0.7.10...HEAD
+[Unreleased]: https://github.com/xmidt-org/tr1d1um/compare/v0.7.11...HEAD
+[v0.7.10]: https://github.com/xmidt-org/tr1d1um/compare/v0.7.10...v0.7.11
 [v0.7.10]: https://github.com/xmidt-org/tr1d1um/compare/v0.7.9...v0.7.10
 [v0.7.9]: https://github.com/xmidt-org/tr1d1um/compare/v0.7.8...v0.7.9
 [v0.7.8]: https://github.com/xmidt-org/tr1d1um/compare/v0.7.7...v0.7.8


### PR DESCRIPTION
What's include:
- [No Prom Metrics Being Produced #329](https://github.com/xmidt-org/tr1d1um/issues/329)
