### PR TITLE
Bug: Limit device status codes used as tr1d1um's resp status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - [Bug: Add ancla watcher to fx lifecycle #361](https://github.com/xmidt-org/tr1d1um/issues/361)
+- [Tr1d1um Panic: device status code used as the response status code can cause an unrecoverable panic #354](https://github.com/xmidt-org/tr1d1um/issues/354)
 
 ## [v0.8.2]
 - [Fix jwtValidator & capabilityCheck config unpacking #359](https://github.com/xmidt-org/tr1d1um/issues/359)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/xmidt-org/ancla v0.3.11
 	github.com/xmidt-org/arrange v0.3.0
-	github.com/xmidt-org/bascule v0.11.3
+	github.com/xmidt-org/bascule v0.11.4
 	github.com/xmidt-org/candlelight v0.0.13
 	github.com/xmidt-org/clortho v0.0.4
 	github.com/xmidt-org/httpaux v0.3.2
@@ -94,7 +94,7 @@ require (
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
-	google.golang.org/genproto v0.0.0-20230117162540-28d6b9783ac4 // indirect
+	google.golang.org/genproto v0.0.0-20230119192704-9d59e20e5cd1 // indirect
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1330,8 +1330,9 @@ github.com/xmidt-org/bascule v0.8.1/go.mod h1:dPxlbNT3lCwYAtOq2zbzyzTEKgM+azLSbK
 github.com/xmidt-org/bascule v0.9.0/go.mod h1:C64nSBtUTTK/f2/mCvvp/qJhav5raD0T+by68DCp/gU=
 github.com/xmidt-org/bascule v0.10.1/go.mod h1:unqyDUxjulfGFnx4kYWbonTGkVHGWPUjUrBkUi1sjWw=
 github.com/xmidt-org/bascule v0.11.2/go.mod h1:OQ+7pP5xccrTYW+JUCTYXfUWvEy4vBa6ng9ppMGb/1s=
-github.com/xmidt-org/bascule v0.11.3 h1:dFLfTZ5StIXKgJaGDQ7hx2msrKSBUjXYXzrXD2rd7/0=
 github.com/xmidt-org/bascule v0.11.3/go.mod h1:UasUQxPI7TjFmleS6hcdsv3BT1lynvxs6iI7UeV2svk=
+github.com/xmidt-org/bascule v0.11.4 h1:s5ADr3lhMiXc2GCMmsIRSnGT2yopVJjoHPjhpzL9YzE=
+github.com/xmidt-org/bascule v0.11.4/go.mod h1:/MKKhwnktnYeQXFChuYqdE81od+BWbdS/qJPJP7APgo=
 github.com/xmidt-org/candlelight v0.0.5/go.mod h1:j9Q2tzrOAywm+JvvVJjlOmlPJvdlRrOyFjLz33SaU1Y=
 github.com/xmidt-org/candlelight v0.0.12/go.mod h1:H8cWj+dum/HH5Pxpd2uUv2C0VuDPKZ50nNQ7CRT4iuA=
 github.com/xmidt-org/candlelight v0.0.13 h1:+8R7gd16rJUrz/yVOst4YYMB8q/QvMD442kPj+sPSxg=
@@ -2116,8 +2117,8 @@ google.golang.org/genproto v0.0.0-20221205194025-8222ab48f5fc/go.mod h1:1dOng4TW
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230109162033-3c3c17ce83e6/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
-google.golang.org/genproto v0.0.0-20230117162540-28d6b9783ac4 h1:yF0uHwqqYt2tIL2F4hxRWA1ZFX43SEunWAK8MnQiclk=
-google.golang.org/genproto v0.0.0-20230117162540-28d6b9783ac4/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230119192704-9d59e20e5cd1 h1:wSjSSQW7LuPdv3m1IrSN33nVxH/kID6OIKy+FMwGB2k=
+google.golang.org/genproto v0.0.0-20230119192704-9d59e20e5cd1/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -203,7 +203,8 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 
 	if err = wrp.NewDecoderBytes(resp.Body, wrp.Msgpack).Decode(wrpModel); err == nil {
 
-		var deviceResponseModel struct {
+		// device response model
+		var d struct {
 			StatusCode int `json:"statusCode"`
 		}
 
@@ -211,9 +212,9 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 		w.WriteHeader(http.StatusOK)
 		// use the device response status code if it's within 520-599 inclusive
 		// https://github.com/xmidt-org/tr1d1um/issues/354
-		if errUnmarshall := json.Unmarshal(wrpModel.Payload, &deviceResponseModel); errUnmarshall == nil {
-			if 520 <= deviceResponseModel.StatusCode && deviceResponseModel.StatusCode <= 599 {
-				w.WriteHeader(deviceResponseModel.StatusCode)
+		if errUnmarshall := json.Unmarshal(wrpModel.Payload, &d); errUnmarshall == nil {
+			if 520 <= d.StatusCode && d.StatusCode <= 599 {
+				w.WriteHeader(d.StatusCode)
 			}
 		}
 

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -210,7 +210,7 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		// use the device response status code if it's within 520-599 inclusive
+		// use the device response status code if it's within 520-599 (inclusive)
 		// https://github.com/xmidt-org/tr1d1um/issues/354
 		if errUnmarshall := json.Unmarshal(wrpModel.Payload, &d); errUnmarshall == nil {
 			if 520 <= d.StatusCode && d.StatusCode <= 599 {

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -208,10 +208,11 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-
-		// if possible, use the device response status code
+		w.WriteHeader(http.StatusOK)
+		// use the device response status code if it's within 520-599 inclusive
+		// https://github.com/xmidt-org/tr1d1um/issues/354
 		if errUnmarshall := json.Unmarshal(wrpModel.Payload, &deviceResponseModel); errUnmarshall == nil {
-			if deviceResponseModel.StatusCode != 0 && deviceResponseModel.StatusCode != http.StatusInternalServerError {
+			if 520 <= deviceResponseModel.StatusCode && deviceResponseModel.StatusCode <= 599 {
 				w.WriteHeader(deviceResponseModel.StatusCode)
 			}
 		}

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -209,7 +209,6 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
 		// use the device response status code if it's within 520-599 (inclusive)
 		// https://github.com/xmidt-org/tr1d1um/issues/354
 		if errUnmarshall := json.Unmarshal(wrpModel.Payload, &d); errUnmarshall == nil {


### PR DESCRIPTION
What's included:
- [Tr1d1um Panic: device status code used as the response status code can cause an unrecoverable panic #354](https://github.com/xmidt-org/tr1d1um/issues/354)
