### PR TITLE
Release: v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Bug: Add ancla watcher to fx lifecycle #361](https://github.com/xmidt-org/tr1d1um/issues/361)
+
+## [v0.8.3]
+- [Bug: Event related metrics fail to update #361](https://github.com/xmidt-org/tr1d1um/issues/361)
 - [Tr1d1um Panic: device status code used as the response status code can cause an unrecoverable panic #354](https://github.com/xmidt-org/tr1d1um/issues/354)
 
 ## [v0.8.2]
@@ -208,7 +210,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial creation.
 
-[Unreleased]: https://github.com/xmidt-org/tr1d1um/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/xmidt-org/tr1d1um/compare/v0.8.3...HEAD
+[v0.8.3]: https://github.com/xmidt-org/tr1d1um/compare/v0.8.2...v0.8.3
 [v0.8.2]: https://github.com/xmidt-org/tr1d1um/compare/v0.8.1...v0.8.2
 [v0.8.1]: https://github.com/xmidt-org/tr1d1um/compare/v0.8.0...v0.8.1
 [v0.8.0]: https://github.com/xmidt-org/tr1d1um/compare/v0.7.12...v0.8.0


### PR DESCRIPTION
What's included:
- [Bug: Event related metrics fail to update #361](https://github.com/xmidt-org/tr1d1um/issues/361)
- [Tr1d1um Panic: device status code used as the response status code can cause an unrecoverable panic #354](https://github.com/xmidt-org/tr1d1um/issues/354)

closes #354
closes #361 