### PR TITLE
Tracing Header Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Correct tracestate spelling, pass on empty tracestate if none is provided]
+- [Correct tracestate spelling, pass on empty tracestate if none is provided #389](https://github.com/xmidt-org/tr1d1um/pull/389)
 
 ## [v0.8.5]
 - [Add Trace info to WRP Message Header #385](https://github.com/xmidt-org/tr1d1um/pull/385)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Correct tracestate spelling, pass on empty tracestate if none is provided]
 
 ## [v0.8.5]
 - [Add Trace info to WRP Message Header #385](https://github.com/xmidt-org/tr1d1um/pull/385)

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -149,7 +149,7 @@ func decodeRequest(ctx context.Context, r *http.Request) (decodedRequest interfa
 		var traceHeaders []string
 
 		// If there's a traceparent, add it to traceHeaders array
-		// Add tracestate to the traceHeaders array (can be empty)
+		// Also, add tracestate to the traceHeaders array (can be empty)
 		// A tracestate will not exist without a traceparent
 		tp := r.Header.Get("traceparent")
 		if tp != "" {

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -149,17 +149,14 @@ func decodeRequest(ctx context.Context, r *http.Request) (decodedRequest interfa
 		var traceHeaders []string
 
 		// If there's a traceparent, add it to traceHeaders array
+		// Add tracestate to the traceHeaders array (can be empty)
+		// A tracestate will not exist without a traceparent
 		tp := r.Header.Get("traceparent")
 		if tp != "" {
 			tp = "traceparent: " + tp
-			traceHeaders = append(traceHeaders, tp)
-		}
-
-		// If there's a tracestatus, add it to traceHeaders array
-		ts := r.Header.Get("tracestatus")
-		if ts != "" {
-			ts = "tracestatus: " + ts
-			traceHeaders = append(traceHeaders, ts)
+			ts := r.Header.Get("tracestate")
+			ts = "tracestate: " + ts
+			traceHeaders = append(traceHeaders, tp, ts)
 		}
 
 		wrpMsg, err = wrap(payload, tid, mux.Vars(r), partnerIDs, traceHeaders)


### PR DESCRIPTION
- Realized I used `tracestatus` instead of the correct W3C standard header, `tracestate`. This has been corrected.
- Validated that `traceparent` can exist without a `tracestate` but not vice versa. We decided that if a `tracestate` is not passed, we will still set the `tracestate` header in WRP with an empty value. The logic has been updated to match these discoveries/decisions. 