### PR TITLE
fix service config for docker and add local dockerfile

### DIFF
--- a/.release/docker/tr1d1um_spruce.yaml
+++ b/.release/docker/tr1d1um_spruce.yaml
@@ -221,7 +221,7 @@ jwtValidator:
       # Template is a URI template used to fetch keys.  This template may
       # use a single parameter named keyID, e.g. http://keys.com/{keyID}.
       # This field is required and has no default.
-      Template: "http://localhost/{keyID}"
+      Template: "http://themis:6500/keys/{keyID}"
     Refresh:
       Sources:
         # URI is the location where keys are served.  By default, clortho supports
@@ -229,7 +229,7 @@ jwtValidator:
         # such as /etc/foo/bar.jwk.
         #
         # This field is required and has no default.
-        - URI: "http://localhost/available"
+        - URI: "http://themis:6500/keys/available"
 
 authx:
   inbound:

--- a/.release/docker/tr1d1um_spruce.yaml
+++ b/.release/docker/tr1d1um_spruce.yaml
@@ -221,7 +221,9 @@ jwtValidator:
       # Template is a URI template used to fetch keys.  This template may
       # use a single parameter named keyID, e.g. http://keys.com/{keyID}.
       # This field is required and has no default.
+
       Template: "http://themis:6500/keys/{keyID}"
+
     Refresh:
       Sources:
         # URI is the location where keys are served.  By default, clortho supports
@@ -230,6 +232,7 @@ jwtValidator:
         #
         # This field is required and has no default.
         - URI: "http://themis:6500/keys/available"
+
 
 authx:
   inbound:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM docker.io/library/golang:1.19-alpine as builder
 
+COPY . /src
+
 WORKDIR /src
 
 RUN apk add --no-cache --no-progress \
     ca-certificates \
+    make \
     curl
 
 # Download spruce here to eliminate the need for curl in the final image
@@ -11,7 +14,10 @@ RUN mkdir -p /go/bin && \
     curl -L -o /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.29.0/spruce-linux-amd64 && \
     chmod +x /go/bin/spruce
 
-COPY . .
+RUN make build
+
+RUN ls tr1d1um
+
 
 ##########################
 # Build the final image.
@@ -21,7 +27,7 @@ FROM alpine:latest
 
 # Copy over the standard things you'd expect.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt  /etc/ssl/certs/
-COPY tr1d1um /
+COPY --from=builder /src/tr1d1um /
 COPY .release/docker/entrypoint.sh  /
 
 # Copy over spruce and the spruce template file used to make the actual configuration file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM docker.io/library/golang:1.19-alpine as builder
 
-COPY . /src
-
 WORKDIR /src
 
 RUN apk add --no-cache --no-progress \
     ca-certificates \
-    make \
     curl
 
 # Download spruce here to eliminate the need for curl in the final image
@@ -14,10 +11,7 @@ RUN mkdir -p /go/bin && \
     curl -L -o /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.29.0/spruce-linux-amd64 && \
     chmod +x /go/bin/spruce
 
-RUN make build
-
-RUN ls tr1d1um
-
+COPY . .
 
 ##########################
 # Build the final image.
@@ -27,7 +21,7 @@ FROM alpine:latest
 
 # Copy over the standard things you'd expect.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt  /etc/ssl/certs/
-COPY --from=builder /src/tr1d1um /
+COPY tr1d1um /
 COPY .release/docker/entrypoint.sh  /
 
 # Copy over spruce and the spruce template file used to make the actual configuration file.

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,55 @@
+FROM docker.io/library/golang:1.19-alpine as builder
+
+COPY . /src
+
+WORKDIR /src
+
+RUN apk add --no-cache --no-progress \
+    ca-certificates \
+    make \
+    curl
+
+# Download spruce here to eliminate the need for curl in the final image
+RUN mkdir -p /go/bin && \
+    curl -L -o /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.29.0/spruce-linux-amd64 && \
+    chmod +x /go/bin/spruce
+
+
+RUN make build
+
+
+##########################
+# Build the final image.
+##########################
+
+FROM alpine:latest
+
+# Copy over the standard things you'd expect.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt  /etc/ssl/certs/
+COPY --from=builder /src/tr1d1um /
+COPY .release/docker/entrypoint.sh  /
+
+# Copy over spruce and the spruce template file used to make the actual configuration file.
+COPY .release/docker/tr1d1um_spruce.yaml  /tmp/tr1d1um_spruce.yaml
+COPY --from=builder /go/bin/spruce        /bin/
+
+# Include compliance details about the container and what it contains.
+COPY Dockerfile /
+COPY NOTICE     /
+COPY LICENSE    /
+
+# Make the location for the configuration file that will be used.
+RUN     mkdir /etc/tr1d1um/ \
+    &&  touch /etc/tr1d1um/tr1d1um.yaml \
+    &&  chmod 666 /etc/tr1d1um/tr1d1um.yaml
+
+USER nobody
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 6100
+EXPOSE 6101
+EXPOSE 6102
+EXPOSE 6103
+
+CMD ["/tr1d1um"]

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ If you'd like to build it without make, follow these instructions based on your 
 
 - Local testing
 ```bash
-go mod vendor
-docker build -t tr1d1um:local -f deploy/Dockerfile .  
+docker build -t tr1d1um:local -f Dockerfile.local .  
 ```
 This allows you to test local changes to a dependency. For example, you can build 
 a tr1d1um image with the changes to an upcoming changes to [webpa-common](https://github.com/xmidt-org/webpa-common) by using the [replace](https://golang.org/ref/mod#go) directive in your go.mod file like so:
@@ -97,7 +96,7 @@ replace github.com/xmidt-org/webpa-common v1.10.2 => ../webpa-common
 - Building a specific version
 ```bash
 git checkout v0.5.1
-docker build -t tr1d1um:v0.5.1 -f deploy/Dockerfile .
+docker build -t tr1d1um:v0.5.1 -f Dockerfile.local .
 ```
 
 **Additional Info:** If you'd like to stand up a XMiDT docker-compose cluster, read [this](https://github.com/xmidt-org/xmidt/blob/master/deploy/docker-compose/README.md).

--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ The Makefile has the following options you may find helpful:
 * `make build`: builds the Tr1d1um binary in the tr1d1um/src/tr1d1um folder
 * `make docker`: fetches all dependencies from source and builds a Tr1d1um
    docker image
-* `make local-docker`: vendors dependencies and builds a Tr1d1um docker image
-   (recommended for local testing)
 * `make test`: runs unit tests with coverage for Tr1d1um
 * `make clean`: deletes previously-built binaries and object files
 
@@ -87,7 +85,7 @@ If you'd like to build it without make, follow these instructions based on your 
 - Local testing
 ```bash
 go mod vendor
-docker build -t tr1d1um:local -f deploy/Dockerfile .
+docker build -t tr1d1um:local -f deploy/Dockerfile .  
 ```
 This allows you to test local changes to a dependency. For example, you can build 
 a tr1d1um image with the changes to an upcoming changes to [webpa-common](https://github.com/xmidt-org/webpa-common) by using the [replace](https://golang.org/ref/mod#go) directive in your go.mod file like so:


### PR DESCRIPTION
1. spruce config was not pointing to the correct url for sat keys
2. default Dockerfile does not build the service within the container.  This works fine for goreleaser but not local building if the OS architecture doesn't match the docker container.  There was a debate whether to build outside the container locally too with the linux flag, we can do this but it seems weird to force the build of the service outside of the container and couples the release process to local building.  Just my opinion but open to changing it. 