### PR TITLE
update FROM to use --platform=linux/$ARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ## SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 ## SPDX-License-Identifier: Apache-2.0
-FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.19-alpine as builder
+FROM --platform=linux/$ARCH docker.io/library/golang:1.19-alpine as builder
 
 ARG ARCH
 
@@ -21,7 +21,7 @@ COPY . .
 # Build the final image.
 ##########################
 
-FROM --platform=$TARGETPLATFORM alpine:latest
+FROM --platform=linux/$ARCH alpine:latest
 
 # Copy over the standard things you'd expect.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt  /etc/ssl/certs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ## SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 ## SPDX-License-Identifier: Apache-2.0
-FROM docker.io/library/golang:1.19-alpine as builder
+FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.19-alpine as builder
 
 ARG ARCH
 
@@ -21,7 +21,7 @@ COPY . .
 # Build the final image.
 ##########################
 
-FROM alpine:latest
+FROM --platform=$TARGETPLATFORM alpine:latest
 
 # Copy over the standard things you'd expect.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt  /etc/ssl/certs/


### PR DESCRIPTION
## What is this PR out to accomplish?

This PR updates `FROM` in the `Dockerfile` to include `--platform=linux/$ARCH`.

The current runs error out (https://github.com/xmidt-org/tr1d1um/actions/runs/13448107751) due to an `arm64` `buildx` directive disagreeing with the non-platformed `FROM`, which I believe needs additional configuration.

https://docs.docker.com/build/building/multi-platform/#cross-compilation
