### PR TITLE
feat: add service_configs_retries metrics for outbound xmidt calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/goph/emperror v0.17.3-0.20190703203600-60a8d9faa17b
 	github.com/gorilla/mux v1.8.1
 	github.com/justinas/alice v1.2.0
+	github.com/prometheus/client_golang v1.20.5
 	github.com/spf13/cast v1.7.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.19.0
@@ -63,7 +64,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.59.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/main.go
+++ b/main.go
@@ -191,6 +191,7 @@ func tr1d1um(arguments []string) (exitCode int) {
 		arrange.ProvideKey("argusClientTimeout", httpClientTimeout{}),
 		touchstone.Provide(),
 		touchhttp.Provide(),
+		provideMetrics(),
 		ancla.ProvideMetrics(),
 		arrangepprof.HTTP{
 			RouterName: "server_pprof",

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/xmidt-org/touchstone"
+	"go.uber.org/fx"
+)
+
+const (
+	// metric names
+	serviceConfigsRetriesCounter = "service_configs_retries"
+
+	// metric labels
+	apiLabel = "api"
+
+	// metric label values
+	// api
+	stat_api   = "stat"
+	device_api = "device"
+)
+
+func provideMetrics() fx.Option {
+	return touchstone.CounterVec(
+		prometheus.CounterOpts{
+			Name: serviceConfigsRetriesCounter,
+			Help: "Count of retries for xmidt service configs api calls.",
+		},
+		[]string{apiLabel}...,
+	)
+}


### PR DESCRIPTION
service_configs_retries will count retries for the following xmidt service configs api calls:
- `/device`
- `/device/${device}/stat`