### PR TITLE
chore: enable docker builds only for amd64 #618

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,9 @@ jobs:
     with:
       license-skip:          true
       release-type:          program
-      release-docker:        false
+      release-docker:        true
       release-docker-latest: true
+      release-arch-arm64:    false
       release-docker-major:  true
       release-docker-minor:  true
       release-docker-extras: |


### PR DESCRIPTION
docker builds will be enable for amd64 and disabled for arm64 #618